### PR TITLE
feat(cilium): migrate Cilium to Flux-managed Helm release

### DIFF
--- a/docs/cilium-flux.md
+++ b/docs/cilium-flux.md
@@ -1,0 +1,19 @@
+# Cilium Deployment via Flux
+
+## Layout
+- `helm/cilium/repository.yaml` — Flux `HelmRepository` for https://helm.cilium.io (namespace `flux-system`).
+- `infrastructure/cilium/` — Kustomize overlay used by Flux:
+  - `values.yaml` — Helm values capturing kube-proxy replacement, routing mode, IPAM range, and API VIP (`10.10.0.95:6443`).
+  - `kustomization.yaml` — Generates `ConfigMap/cilium-values` (hash disabled) from `values.yaml` and applies the HelmRelease.
+  - `release.yaml` — Flux `HelmRelease` targeting chart version `1.18.2` in namespace `kube-system`.
+
+## Apply Manually (bootstrap)
+```bash
+kubectl apply -f helm/cilium/repository.yaml
+kubectl apply -k infrastructure/cilium
+```
+
+## Notes
+- The Helm release name remains `cilium`; uninstall any existing CLI-installed release first (`helm uninstall cilium -n kube-system`) or let Flux adopt it after removing the old Helm secret.
+- Values keep `kubeProxyReplacement=strict`, `routingMode=tunnel`, and the pod/service CIDRs set to match the cluster (`10.42.0.0/16`, `10.43.0.0/16`).
+- HAProxy load-balancer endpoint (`10.10.0.95:6443`) is wired through `k8sServiceHost`/`k8sServicePort` so agents can talk to the API during bootstrap.

--- a/helm/cilium/repository.yaml
+++ b/helm/cilium/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cilium
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: https://helm.cilium.io/

--- a/infrastructure/cilium/kustomization.yaml
+++ b/infrastructure/cilium/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../helm/cilium/repository.yaml
+  - release.yaml
+configMapGenerator:
+  - name: cilium-values
+    namespace: kube-system
+    files:
+      - values.yaml
+    options:
+      disableNameSuffixHash: true

--- a/infrastructure/cilium/release.yaml
+++ b/infrastructure/cilium/release.yaml
@@ -1,0 +1,28 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
+kind: HelmRelease
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  releaseName: cilium
+  interval: 10m
+  targetNamespace: kube-system
+  chart:
+    spec:
+      chart: cilium
+      version: 1.18.2
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+        namespace: flux-system
+      interval: 5m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: cilium-values
+      valuesKey: values.yaml

--- a/infrastructure/cilium/values.yaml
+++ b/infrastructure/cilium/values.yaml
@@ -1,0 +1,13 @@
+k8sServiceHost: 10.10.0.95
+k8sServicePort: 6443
+cluster:
+  name: default
+ipam:
+  operator:
+    clusterPoolIPv4PodCIDRList:
+      - 10.42.0.0/16
+kubeProxyReplacement: true
+routingMode: tunnel
+tunnelProtocol: vxlan
+operator:
+  replicas: 1


### PR DESCRIPTION
  - add Flux-compatible HelmRepository manifest for the Cilium chart
  - define HelmRelease + kustomize wrapper that generates the configmap values
  - upgrade Cilium to chart 1.18.2 with HAProxy control-plane VIP and strict kube-proxy
  replacement
  - document the Flux workflow for managing Cilium